### PR TITLE
fix(web): 修复LLM返回内容包含HTML标签导致的XSS问题

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2191,7 +2191,7 @@ function renderLLMResponse(msg, isHistory = false) {
     }
 
   } else {
-    htmlContent += `<div style="white-space:pre-wrap;color:#e2e8f0;">${content}</div>`;
+    htmlContent += `<div style="white-space:pre-wrap;color:#e2e8f0;">${escapeHtml(content)}</div>`;
   }
 
   div.innerHTML = htmlContent;


### PR DESCRIPTION
修复LLM返回内容包含HTML标签导致的XSS问题。当LLM返回<iframe>、<script>alert(1)</alert>等标签时，会造成XSS。