### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,4 +606,4 @@ LuaN1aoAgent v2 is licensed under the [GNU Affero General Public License v3.0](L
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)](https://www.star-history.com/?repos=SanMuzZzZz%2FLuaN1aoAgent&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)](https://star-history.dera.page/#SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)

--- a/README_CN.md
+++ b/README_CN.md
@@ -581,4 +581,4 @@ LuaN1aoAgent v2 采用 [GNU Affero General Public License v3.0](LICENSE)（`AGPL
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)](https://www.star-history.com/?repos=SanMuzZzZz%2FLuaN1aoAgent&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)](https://star-history.dera.page/#SanMuzZzZz/LuaN1aoAgent&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart on the README has been broken, preventing visitors from seeing the project's growth over time. This change points the chart to a working provider so it renders correctly again, in both the English and Chinese READMEs.